### PR TITLE
Throw exception instead of just exiting

### DIFF
--- a/src/lib/Combiner.php
+++ b/src/lib/Combiner.php
@@ -83,10 +83,7 @@ class Combiner {
 				call_user_func($this->checkpointer,$result);
 			}
 			if(!$result['success']) {
-				/**
-				* @todo we need to kill this process osmehow
-				*/
-				exit();
+				throw new \Exception("Could not put message on bus - result is: " . $result);
 			} 
 		}
 	}


### PR DESCRIPTION
If failed to put message on the bus, we need to throw an exception instead of just exiting.  This is leading to problems where the errors are swallowed and we aren't seeing why events aren't getting onto bus.  Eventually, we need to add retries for this too.